### PR TITLE
Drop conda for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,19 +25,16 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          auto-update-conda: true
 
       - name: Test
         run: |
           pip install nox
-          nox -s test test-cli --force-pythons="${{ matrix.python-version }}"
+          nox -s test test-cli --force-python ${{ matrix.python-version }}
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest'

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,18 +3,17 @@ import shutil
 
 import nox
 
-PYTHON_VERSION = "3.12"
 ROOT = pathlib.Path(__file__).parent
 
 
-@nox.session(python=PYTHON_VERSION, venv_backend="conda")
+@nox.session
 def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install("-e", ".[testing]")
     session.run("pytest", "-vvv")
 
 
-@nox.session(name="test-cli", python=PYTHON_VERSION, venv_backend="conda")
+@nox.session(name="test-cli")
 def test_cli(session: nox.Session) -> None:
     """Test the command line interface."""
     session.install(".")


### PR DESCRIPTION
I've dropped *conda* for testing in both the *noxfile* and the GtiHub actions. It was slow and unnecessary.