### PR TITLE
Rename package to grist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# egret
+# grist
 
-The *egret* utility searches directory trees for input files, selecting lines
+The *grist* utility searches directory trees for input files, selecting lines
 that match a pattern.  By default, a pattern matches an input line if the
 regular expression in the pattern matches the input line without its
 trailing newline.  An empty expression matches every line.  Each input line that

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,8 +17,8 @@ def test(session: nox.Session) -> None:
 def test_cli(session: nox.Session) -> None:
     """Test the command line interface."""
     session.install(".")
-    session.run("egret", "--help")
-    session.run("egret", "--version")
+    session.run("grist", "--help")
+    session.run("grist", "--version")
 
 
 @nox.session
@@ -71,7 +71,7 @@ def clean(session):
         with session.chdir(folder):
             shutil.rmtree("build", ignore_errors=True)
             shutil.rmtree("build/wheelhouse", ignore_errors=True)
-            shutil.rmtree("egret.egg-info", ignore_errors=True)
+            shutil.rmtree("grist.egg-info", ignore_errors=True)
             shutil.rmtree(".pytest_cache", ignore_errors=True)
             shutil.rmtree(".venv", ignore_errors=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "egret"
+name = "grist"
 description = "grep python files"
 authors = [
   {email = "mcflugen@gmail.com"},
@@ -40,29 +40,29 @@ dependencies = [
 dynamic = ["readme", "version"]
 
 [project.urls]
-homepage = "https://github.com/mcflugen/egret"
-documentation = "https://github.com/mcflugen/egret/blob/main/README.md"
-repository = "https://github.com/mcflugen/egret"
-changelog = "https://github.com/mcflugen/egret/blob/main/CHANGES.md"
+homepage = "https://github.com/mcflugen/grist"
+documentation = "https://github.com/mcflugen/grist/blob/main/README.md"
+repository = "https://github.com/mcflugen/grist"
+changelog = "https://github.com/mcflugen/grist/blob/main/CHANGES.md"
 
 [project.optional-dependencies]
 dev = ["nox"]
 testing = ["pytest"]
 
 [project.scripts]
-egret = "egret:main"
+grist = "grist:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-py-modules = ["egret"]
+py-modules = ["grist"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md", "AUTHORS.md", "CHANGES.md"], content-type="text/markdown"}
-version = {attr = "egret.__version__"}
+version = {attr = "grist.__version__"}
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-testpaths = ["tests", "egret.py"]
+testpaths = ["tests", "grist.py"]
 norecursedirs = [".*", "*.egg*", "build", "dist", "utilities"]
 addopts = """
   --ignore setup.py

--- a/src/grist.py
+++ b/src/grist.py
@@ -45,10 +45,10 @@ def main() -> int:
     )
     config_parser.add_argument("--config", help="Specify config file", metavar="FILE")
     config_parser.add_argument(
-        "--version", action="version", version=f"egret {__version__}"
+        "--version", action="version", version=f"grist {__version__}"
     )
 
-    parser = argparse.ArgumentParser(prog="egret", parents=[config_parser])
+    parser = argparse.ArgumentParser(prog="grist", parents=[config_parser])
     args, _ = config_parser.parse_known_args()
 
     defaults = ChainMap(
@@ -57,7 +57,7 @@ def main() -> int:
         DEFAULTS,
     )
 
-    parser = argparse.ArgumentParser(prog="egret", parents=[config_parser])
+    parser = argparse.ArgumentParser(prog="grist", parents=[config_parser])
     parser.set_defaults(**defaults)
 
     parser.add_argument("pattern", metavar="PATTERN")
@@ -216,10 +216,10 @@ def main() -> int:
 
 def find_user_config_file() -> str:
     if sys.platform == "win32":
-        user_config_path = pathlib.Path.home() / ".egret.toml"
+        user_config_path = pathlib.Path.home() / ".grist.toml"
     else:
         config_root = os.environ.get("XDG_CONFIG_HOME", "~/.config")
-        user_config_path = pathlib.Path(config_root).expanduser() / "egret.toml"
+        user_config_path = pathlib.Path(config_root).expanduser() / "grist.toml"
     return str(user_config_path.resolve())
 
 
@@ -227,7 +227,7 @@ def parse_config_toml(path_to_config: str | None) -> dict[str, Any]:
     if path_to_config is not None and pathlib.Path(path_to_config).is_file():
         with open(path_to_config, "rb") as fp:
             config_toml = tomllib.load(fp)
-        config: dict[str, Any] = config_toml.get("tool", {}).get("egret", {})
+        config: dict[str, Any] = config_toml.get("tool", {}).get("grist", {})
         config = {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
     else:
         config = {}

--- a/tests/collect_test.py
+++ b/tests/collect_test.py
@@ -4,7 +4,7 @@ import pathlib
 import subprocess
 import textwrap
 
-import egret
+import grist
 import pytest
 
 
@@ -20,7 +20,7 @@ def as_cwd(path):
 FILES = {
     ".git/foo.py": "import bar",
     "bar.toml": textwrap.dedent("""\
-        [tool.egret]
+        [tool.grist]
         types = ["ini"]
         """),
     "foo.py": "import bar",
@@ -44,7 +44,7 @@ def git_dir(tmp_path_factory):
 
 def test_in_dot_git(git_dir):
     with pytest.raises(RuntimeError):
-        egret.GitFiles(git_dir / ".git")
+        grist.GitFiles(git_dir / ".git")
 
 
 @pytest.mark.parametrize(
@@ -56,7 +56,7 @@ def test_in_dot_git(git_dir):
 )
 def test_git_files(git_dir, file_type, expected):
     with as_cwd(git_dir):
-        assert sorted(egret.GitFiles(types_or=(file_type,)).collect()) == expected
+        assert sorted(grist.GitFiles(types_or=(file_type,)).collect()) == expected
 
 
 @pytest.mark.parametrize(
@@ -70,5 +70,5 @@ def test_walk_files(git_dir, file_type, expected):
     with as_cwd(git_dir):
         assert [
             pathlib.Path(f)
-            for f in sorted(egret.WalkFiles(types_or=(file_type,)).collect())
+            for f in sorted(grist.WalkFiles(types_or=(file_type,)).collect())
         ] == [pathlib.Path(f) for f in expected]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,22 +1,22 @@
 import pathlib
 import sys
 
-import egret
+import grist
 import pytest
 
 
 def test_find_config_file(monkeypatch):
     if sys.platform == "win32":
-        path_to_config = egret.find_user_config_file()
+        path_to_config = grist.find_user_config_file()
         assert (
-            pathlib.Path(path_to_config) == pathlib.Path("~/.egret.toml").expanduser()
+            pathlib.Path(path_to_config) == pathlib.Path("~/.grist.toml").expanduser()
         )
     else:
         with monkeypatch.context() as mp:
             mp.setenv("XDG_CONFIG_HOME", "/not/a/real/dir")
-            path_to_config = egret.find_user_config_file()
+            path_to_config = grist.find_user_config_file()
 
-        assert path_to_config == "/not/a/real/dir/egret.toml"
+        assert path_to_config == "/not/a/real/dir/grist.toml"
 
 
 @pytest.mark.parametrize(
@@ -30,27 +30,27 @@ def test_find_config_file(monkeypatch):
 )
 def test_parse_config(tmpdir, option):
     with tmpdir.as_cwd():
-        with open("egret.toml", "w") as fp:
+        with open("grist.toml", "w") as fp:
             print(
                 f"""
-[tool.egret]
+[tool.grist]
 {option} = "ini"
                 """,
                 file=fp,
             )
-        config = egret.parse_config_toml("egret.toml")
+        config = grist.parse_config_toml("grist.toml")
 
     assert config == {"extend_types_or": "ini"}
 
 
-@pytest.mark.parametrize("contents", ("", "[tool.egret]"))
+@pytest.mark.parametrize("contents", ("", "[tool.grist]"))
 def test_parse_config_empty_contents(tmpdir, contents):
     with tmpdir.as_cwd():
-        with open("egret.toml", "w") as fp:
+        with open("grist.toml", "w") as fp:
             print(contents, file=fp)
-        assert egret.parse_config_toml("egret.toml") == {}
+        assert grist.parse_config_toml("grist.toml") == {}
 
 
 @pytest.mark.parametrize("arg", (None, "/not/a/file.toml"))
 def test_parse_config_empty(arg):
-    assert egret.parse_config_toml(arg) == {}
+    assert grist.parse_config_toml(arg) == {}


### PR DESCRIPTION
I've rename the *egret* package to *grist*. I like *egret* but it was already taken on *PyPI*. I thought *grist* was a nice alternative that wasn't taken.