### PR TITLE
Switch to CodeCov for coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,22 +34,10 @@ jobs:
       - name: Test
         run: |
           pip install nox
-          nox -s test test-cli --force-python ${{ matrix.python-version }}
+          nox -s coverage test-cli --force-python ${{ matrix.python-version }}
 
-      - name: Coveralls
-        if: matrix.os == 'ubuntu-latest'
-        uses: AndreMiras/coveralls-python-action@develop
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          parallel: true
-          flag-name: py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.pytest-marker }}
-          debug: true
-
-  coveralls_finish:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel-finished: true
-          debug: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: mcflugen/grist

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import shutil
 
@@ -19,6 +20,28 @@ def test_cli(session: nox.Session) -> None:
     session.install(".")
     session.run("grist", "--help")
     session.run("grist", "--version")
+
+
+@nox.session
+def coverage(session: nox.Session) -> None:
+    """Run coverage."""
+    session.install("coverage", "pytest")
+    session.install("-e", ".")
+
+    session.run(
+        "coverage",
+        "run",
+        "-m",
+        "pytest",
+        "src/grist.py",
+        "tests",
+        "--doctest-modules",
+        env={"COVERAGE_CORE": "sysmon"},
+    )
+
+    session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    if "CI" in os.environ:
+        session.run("coverage", "xml", "-o", "coverage.xml")
 
 
 @nox.session


### PR DESCRIPTION
I've switched from using *coveralls* to *codecov* for *grist*'s coverage.