### PR TITLE
Add --add-type option to the grist cli

### DIFF
--- a/src/grist.py
+++ b/src/grist.py
@@ -160,6 +160,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     group.add_argument(
+        "--add-type",
+        dest="add_types",
+        action="append",
+        metavar="TYPE",
+        default=None,
+        type=_validate_type,
+        help="add this type (repeatable) to the current type set",
+    )
+    group.add_argument(
         "--no-type",
         dest="no_types",
         action="append",
@@ -209,7 +218,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    all_types = set(args.types if args.types is not None else defaults["types"])
+    all_types = set(args.types if args.types is not None else defaults["types"]) | set(
+        args.add_types if args.add_types else {}
+    )
     no_types = set(args.no_types if args.no_types is not None else defaults["no_types"])
 
     encoding = set()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -51,6 +51,23 @@ def test_type(capsys, tmpdir, toml, python):
     assert matches == expected
 
 
+@pytest.mark.parametrize("python", (True, False))
+@pytest.mark.parametrize("toml", (True, False))
+def test_add_type(capsys, tmpdir, toml, python):
+    (tmpdir / "baz.py").write_text("foobar\n", encoding="utf-8")
+    (tmpdir / "baz.toml").write_text("foobar\n", encoding="utf-8")
+
+    expected = {name for ok, name in ((python, "baz.py"), (toml, "baz.toml")) if ok}
+    args = ["--type=json"] + [
+        f"--add-type={tag}" for ok, tag in ((toml, "toml"), (python, "python")) if ok
+    ]
+    with tmpdir.as_cwd():
+        main(["--walk", "foobar", "-l", *args])
+
+    matches = {line.strip() for line in capsys.readouterr().out.splitlines()}
+    assert matches == expected
+
+
 @pytest.mark.parametrize("text", (True, False))
 @pytest.mark.parametrize("binary", (True, False))
 def test_encoding(capsys, tmpdir, text, binary):


### PR DESCRIPTION
I've added a new option, `--add-type`, that adds a type or types to the current list of file types being searched.